### PR TITLE
Setup Idea workspace task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ run/
 /fabricloader.log
 
 mods/
+logs/

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,5 @@ bin/
 src/main/java/io/github/minifabric/example/mixin/TreeTileMixin.java
 run/
 /fabricloader.log
+
+mods/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 ## Setup
 
-No real setup instructions yet, but it should be very similar to the setup explained on the [fabric wiki page](https://fabricmc.net/wiki/tutorial:setup), until you hit "Generating Minecraft Sources", after which you're already done as Minicraft is not obfuscated.
+At this moment automatic setup is available only for IntelliJ Idea.
+You also need Java 17
+
+1. Clone this repo (with `git clone` or manual zip download)
+2. Open command line/terminal, switch active directory to project root and execute `gradlew setupIdeaWorkspace`
+3. Import your project into Idea as gradle project
+
+You will get "Launch Client" configuration that will start game with your mod
 
 ## License
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,39 +1,39 @@
 plugins {
-	id 'maven-publish'
-	id 'java'
+	id "maven-publish"
+	id "java"
 }
 
 version = project.mod_version
 group = project.maven_group
 
+@Grab('org.codehaus.groovy:groovy-xml:3.0.9')
+import groovy.xml.MarkupBuilder
+
 repositories {
 	maven {
-		name = 'Fabric'
-		url = 'https://maven.fabricmc.net/'
+		name = "Fabric"
+		url = "https://maven.fabricmc.net/"
 	}
 	maven {
-		name = 'jitpack'
-		url = 'https://jitpack.io'
+		name = "jitpack"
+		url = "https://jitpack.io"
 	}
 	maven {
-		name = 'MiniFabric'
-		url = 'https://repo.repsy.io/mvn/distant/minifabric/'
+		name = "MiniFabric"
+		url = "https://repo.repsy.io/mvn/distant/minifabric/"
 	}
-	maven {
-		name = 'MinicraftPlus'
-		url = 'https://repo.repsy.io/mvn/minicraftplus/minicraft'
-	}
+	maven { url 'https://jitpack.io' }
 	mavenCentral()
 	mavenLocal()
 }
 
 dependencies {
-	implementation "java.minicraft:minicraft-plus-revived:${project.minicraftplus_version}"
+	implementation "com.github.MinicraftPlus:minicraft-plus-revived:${project.minicraftplus_version}"
 	implementation "io.github.pseudodistant:MinicraftGameProvider:${project.provider_version}"
 	implementation "net.fabricmc:fabric-loader:${project.loader_version}"
-	implementation 'org.tinylog:tinylog-api:2.4.1'
-	implementation 'org.tinylog:tinylog-impl:2.4.1'
-	implementation 'org.jetbrains:annotations:22.0.0'
+	implementation "org.tinylog:tinylog-api:2.4.1"
+	implementation "org.tinylog:tinylog-impl:2.4.1"
+	implementation "org.jetbrains:annotations:22.0.0"
 	implementation "net.fabricmc:sponge-mixin:0.11.0+mixin.0.8.5"
 	implementation "net.fabricmc:access-widener:2.1.0"
 	implementation "com.fasterxml.jackson.core:jackson-databind:2.13.1"
@@ -48,7 +48,7 @@ processResources {
 }
 
 tasks.withType(JavaCompile).configureEach {
-	it.options.release = 16
+	it.options.release = 17
 }
 
 java {
@@ -62,6 +62,40 @@ sourcesJar {
 jar {
 	from("LICENSE") {
 		rename { "${it}_${project.archivesBaseName}"}
+	}
+}
+
+task copyMod {
+	doLast {
+		copy {
+			from jar
+			into "mods"
+		}
+	}
+}
+
+build.dependsOn copyMod
+
+task setupIdeaWorkspace {
+	doLast {
+		project.file(".idea/runConfigurations").mkdirs()
+
+		def writer = new FileWriter(new File(".idea/runConfigurations/Launch_Client.xml"))
+		def xml = new MarkupBuilder(writer)
+		def jarPath = "-Dfabric.gameJarPath=\"" + configurations.compileClasspath[0] + "\""
+
+		xml.component(name: "ProjectRunConfigurationManager") {
+			configuration(default: "false", name: "Launch Client", type: "Application", factoryName: "Application") {
+				option(name: "ALTERNATIVE_JRE_PATH", value: "17")
+				option(name: "ALTERNATIVE_JRE_PATH_ENABLED", value: "true")
+				option(name: "MAIN_CLASS_NAME", value: "net.fabricmc.loader.impl.launch.knot.KnotClient")
+				option(name: "VM_PARAMETERS", value: jarPath)
+				module(name: "MiniFabric-example-mod-master.main")
+				method(v: "2") {
+					option(name: "Gradle.BeforeRunTask", enabled: "true", tasks: "build", externalProjectPath: "\$PROJECT_DIR\$", vmOptions: "", scriptParameters: "")
+				}
+			}
+		}
 	}
 }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,11 +1,11 @@
 org.gradle.jvmargs=-Xmx1G
 
-	minicraftplus_version=2.1.0-dev3
-	loader_version=0.13.3
-	provider_version=1.1.2
+minicraftplus_version=2.2.0-dev1
+loader_version=0.13.3
+provider_version=1.1.2
 
 # Mod Properties
-	mod_version = 1.0.0
-	maven_group = com.example
-	archives_base_name = fabric-example-mod
+mod_version = 1.0.0
+maven_group = com.example
+archives_base_name = fabric-example-mod
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/io/github/minifabric/example/ExampleMod.java
+++ b/src/main/java/io/github/minifabric/example/ExampleMod.java
@@ -3,7 +3,6 @@ package io.github.minifabric.example;
 import net.fabricmc.api.ModInitializer;
 
 public class ExampleMod implements ModInitializer {
-
 	@Override
 	public void onInitialize() {
 		System.out.println("Hello Fabric world!");

--- a/src/main/java/io/github/minifabric/example/mixin/ExampleMixin.java
+++ b/src/main/java/io/github/minifabric/example/mixin/ExampleMixin.java
@@ -8,7 +8,6 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Game.class)
 public class ExampleMixin {
-
 	@Inject(at = @At("HEAD"), method = "main")
 	private static void init(CallbackInfo info) {
 		System.out.println("This line is printed by an example mod mixin!");

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,37 +1,37 @@
 {
-  "schemaVersion": 1,
-  "id": "modid",
-  "version": "${version}",
+	"schemaVersion": 1,
+	"id": "modid",
+	"version": "${version}",
 
-  "name": "Example Mod",
-  "description": "This is an example description! Tell everyone what your mod is about!",
-  "authors": [
-    "Me!"
-  ],
-  "contact": {
-    "homepage": "https://minifabric.github.io/",
-    "sources": "https://github.com/MiniFabric/MiniFabric-example-mod"
-  },
+	"name": "Example Mod",
+	"description": "This is an example description! Tell everyone what your mod is about!",
+	"authors": [
+		"Me!"
+	],
+	"contact": {
+		"homepage": "https://minifabric.github.io/",
+		"sources": "https://github.com/MiniFabric/MiniFabric-example-mod"
+	},
 
-  "license": "CC0-1.0",
-  "icon": "assets/modid/icon.png",
+	"license": "CC0-1.0",
+	"icon": "assets/modid/icon.png",
 
-  "environment": "*",
-  "entrypoints": {
-    "main": [
-      "io.github.minifabric.example.ExampleMod"
-    ]
-  },
-  "mixins": [
-    "modid.mixins.json"
-  ],
+	"environment": "*",
+	"entrypoints": {
+		"main": [
+			"io.github.minifabric.example.ExampleMod"
+		]
+	},
+	"mixins": [
+		"modid.mixins.json"
+	],
 
-  "depends": {
-    "fabricloader": ">=0.13.0",
-    "minicraftplus": "*",
-    "java": ">=16"
-  },
-  "suggests": {
-    "another-mod": "*"
-  }
+	"depends": {
+		"fabricloader": ">=0.13.0",
+		"minicraftplus": "*",
+		"java": ">=16"
+	},
+	"suggests": {
+		"another-mod": "*"
+	}
 }

--- a/src/main/resources/modid.mixins.json
+++ b/src/main/resources/modid.mixins.json
@@ -1,14 +1,14 @@
 {
-  "required": true,
-  "minVersion": "0.8",
-  "package": "io.github.minifabric.example.mixin",
-  "compatibilityLevel": "JAVA_16",
-  "mixins": [
-    "ExampleMixin"
-  ],
-  "client": [
-  ],
-  "injectors": {
-    "defaultRequire": 1
-  }
+	"required": true,
+	"minVersion": "0.8",
+	"package": "io.github.minifabric.example.mixin",
+	"compatibilityLevel": "JAVA_17",
+	"mixins": [
+		"ExampleMixin"
+	],
+	"client": [
+	],
+	"injectors": {
+		"defaultRequire": 1
+	}
 }


### PR DESCRIPTION
This PR implements `setupIdeaWorkspace` task, it will create Idea launch configuration that will start mod from IDE.

Now to start modding you need to run `gradlew setupIdeaWorkspace` first and then load project into Idea. It is possible to run that task in Idea itself, but it will be better to launch it before project importing

Additionally this PR does:
- Update gradle to 8.3
- Update Java version to 17
- Update Minicraft+ version to 2.2.0-pre1 (the most stable from recent releases)